### PR TITLE
Drop branches for selections in Job and Region blocks

### DIFF
--- a/servicex_for_trexfitter/__init__.py
+++ b/servicex_for_trexfitter/__init__.py
@@ -3,4 +3,4 @@
 from .servicex_for_trexfitter import ServiceXTRExFitter
 
 __all__ = ['ServiceXTRExFitter', ]
-__version__ = '0.6.5'
+__version__ = '0.7.0'

--- a/servicex_for_trexfitter/load_servicex_requests.py
+++ b/servicex_for_trexfitter/load_servicex_requests.py
@@ -136,16 +136,16 @@ class LoadServiceXRequests():
     def get_columns_in_job(self):
         columns = []
         job = self._trex_config.__dict__['_trex_config']['Job0']
-        if 'Selection' in job:
-            columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(job['Selection']))
+        # if 'Selection' in job:
+        #     columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(job['Selection']))
         if 'MCweight' in job:
             columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(job['MCweight']))
         return columns
 
     def get_columns_in_sample(self, sample):
         columns = []
-        if 'Selection' in sample:
-            columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(sample['Selection']))
+        # if 'Selection' in sample:
+        #     columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(sample['Selection']))
         if 'MCweight' in sample:
             columns = columns + self.get_list_of_columns_in_string(self.replace_XXX(sample['MCweight']))
         return columns


### PR DESCRIPTION
- Compatible with the update in the TRExFitter framework which ignores selections in Job and Sample blocks by using an option `UseServiceX` in the Job block
- This update significantly reduces the delivered data size by ServiceX and improves the overall performance.
- MR at TRExFitter framework repo: https://gitlab.cern.ch/TRExStats/TRExFitter/-/merge_requests/852