### PR TITLE
Parallelize parquet to root. Minor updates.

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: Install conda dependencies
     #   shell: bash -l {0}
       run: |
-        conda install -c conda-forge root
+        conda install -c conda-forge root=6.22.8
         conda install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest

--- a/servicex_for_trexfitter/__init__.py
+++ b/servicex_for_trexfitter/__init__.py
@@ -3,4 +3,4 @@
 from .servicex_for_trexfitter import ServiceXTRExFitter
 
 __all__ = ['ServiceXTRExFitter', ]
-__version__ = '0.8.1'
+__version__ = '0.9.0'

--- a/servicex_for_trexfitter/communicate_servicex.py
+++ b/servicex_for_trexfitter/communicate_servicex.py
@@ -1,5 +1,4 @@
 import asyncio
-from aiohttp.connector import BaseConnector
 import tcut_to_qastle as tq
 from servicex import ServiceXDataset
 from aiohttp import ClientSession

--- a/servicex_for_trexfitter/communicate_servicex.py
+++ b/servicex_for_trexfitter/communicate_servicex.py
@@ -25,7 +25,7 @@ class ServiceXFrontend:
         async def _get_my_data():
             sem = asyncio.Semaphore(50) # Limit maximum concurrent ServiceX requests
             tasks = []
-            ignore_cache = True
+            ignore_cache = False
             uproot_transformer_image = "sslhep/servicex_func_adl_uproot_transformer:develop"
             async with ClientSession() as session:
                 for request in self._servicex_requests:

--- a/servicex_for_trexfitter/make_ntuples.py
+++ b/servicex_for_trexfitter/make_ntuples.py
@@ -1,40 +1,63 @@
 from pathlib import Path
 from parquet_to_root import parquet_to_root
 from ROOT import TFile
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 
+class MakeNtuples:
 
-def make_ntuples(trex_config, sx_requests, output_parquet_list):
+    def __init__(self, trex_config):
+        self._trex_config = trex_config
 
-    if len(sx_requests) is len(output_parquet_list):
-        pass
-    else:
-        raise ValueError('Something went wrong.. '
-                         'Number of requests and outputs do not agree.' 
-                         'It might be due to the failed transformations')
+    def write_root_ntuple(self, results):
 
-    print('\nConverting ServiceX delivered parquet to ROOT Ntuple..')
+        sam = results[0][0]['Sample']
+        print(f"Writing Sample - {sam}")
 
-    # Create output directory
-    Path(trex_config.get_job_block('NtuplePath')).mkdir(parents=True, exist_ok=True)
+        output_file_name = f"{self._trex_config.get_job_block('NtuplePath')}/{sam}.root"
+        
+        for tree in results: # loop over requests (different TTree)
+            tree_name = tree[0]['ntupleName']
+            out_parquet_list = tree[1]
+            if tree_name != 'nominal':
+                output_file = TFile.Open(output_file_name, 'UPDATE')
+                parquet_to_root(out_parquet_list, output_file, tree_name, verbose=False)
+                output_file.Close()
+            else:
+                parquet_to_root(out_parquet_list, output_file_name, tree_name, verbose=False)
 
-    # ROOT file per SAMPLE
-    sam_old = ""
-    for (request, output) in zip(sx_requests, output_parquet_list):
-        # output_file_name = trex_config.get_job_block('NtuplePath') + "/" + request['Sample'] + ".root"
-        output_file_name = f"{trex_config.get_job_block('NtuplePath')}/{request['Sample']}.root"
+    def make_ntuples(self, sx_requests, output_parquet_list):
 
-        sam = request['Sample']
-        if sam is not sam_old:
-            print(f"  Sample: {sam}")
-            sam_old = sam
-        print(f"    TTree: {request['ntupleName']}")
-
-        if request['ntupleName'] != 'nominal':
-            output_file = TFile.Open(output_file_name, 'UPDATE')
-            parquet_to_root(output, output_file, request['ntupleName'], verbose=False)
-            output_file.Close()
+        if len(sx_requests) is len(output_parquet_list):
+            pass
         else:
-            parquet_to_root(output, output_file_name, request['ntupleName'], verbose=False)
+            raise ValueError('Something went wrong.. '
+                            'Number of requests and outputs do not agree.' 
+                            'It might be due to the failed transformations')
 
-    return trex_config.get_job_block('NtuplePath')
+        print('\nConverting ServiceX delivered parquet to ROOT Ntuple..')
+
+        # Create output directory
+        Path(self._trex_config.get_job_block('NtuplePath')).mkdir(parents=True, exist_ok=True)
+        
+        # List of Samples
+        samples = list(dict.fromkeys([request['Sample'] for request in sx_requests]))
+
+        # Pair of request and parquet output list
+        result_pairs = [(request, output) for (request, output) in zip(sx_requests, output_parquet_list)]
+
+        # dict of pairs for each sample
+        results = {}
+        for sample in samples:
+            for pair in result_pairs:
+                if pair[0]['Sample'] == sample:
+                    if sample in results:
+                        results[sample].append(pair)
+                    else:
+                        results[sample] = [pair]
+        results_ordered = list(results.values())
+
+        nproc = min(len(samples), int(cpu_count()/2))
+        with Pool(processes=nproc) as pool:
+            pool.map(self.write_root_ntuple, results_ordered)
+
+        return self._trex_config.get_job_block('NtuplePath')

--- a/servicex_for_trexfitter/make_ntuples.py
+++ b/servicex_for_trexfitter/make_ntuples.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from parquet_to_root import parquet_to_root
 from ROOT import TFile
+from multiprocessing import Pool
 
 
 def make_ntuples(trex_config, sx_requests, output_parquet_list):
@@ -8,19 +9,20 @@ def make_ntuples(trex_config, sx_requests, output_parquet_list):
     if len(sx_requests) is len(output_parquet_list):
         pass
     else:
-        raise ValueError('Number of requests and outputs do not agree. It might be due to the failed transformations')
+        raise ValueError('Something went wrong.. '
+                         'Number of requests and outputs do not agree.' 
+                         'It might be due to the failed transformations')
 
-    print('Converting parquet to ROOT Ntuple..')
+    print('\nConverting ServiceX delivered parquet to ROOT Ntuple..')
 
     # Create output directory
-    # Path(trex_config.get_job_block('Job') + "/Data").mkdir(parents=True, exist_ok=True)
     Path(trex_config.get_job_block('NtuplePath')).mkdir(parents=True, exist_ok=True)
 
     # ROOT file per SAMPLE
     sam_old = ""
     for (request, output) in zip(sx_requests, output_parquet_list):
-        # output_file_name = trex_config.get_job_block('Job') + "/Data/" + request['Sample'] + ".root"
-        output_file_name = trex_config.get_job_block('NtuplePath') + "/" + request['Sample'] + ".root"
+        # output_file_name = trex_config.get_job_block('NtuplePath') + "/" + request['Sample'] + ".root"
+        output_file_name = f"{trex_config.get_job_block('NtuplePath')}/{request['Sample']}.root"
 
         sam = request['Sample']
         if sam is not sam_old:

--- a/servicex_for_trexfitter/read_trex_config.py
+++ b/servicex_for_trexfitter/read_trex_config.py
@@ -13,7 +13,8 @@ def read_configuration(confFile: str, block_name: str):
         for mark, line in enumerate(configFile.readlines()):
             if re.search(r'\b{}\b'.format(block_name), line):
                 block[block_name+str(num)] = {}
-                block[block_name+str(num)][line.split()[0].strip(':')] = line.split(":")[1].strip("\n").strip().strip('\"')
+                block[block_name+str(num)][line.split()[0].strip(':')] \
+                    = line.split(":")[1].strip("\n").strip().strip('\"')
                 inlines = mark + 2
                 while inlines:
                     inline = linecache.getline(confFile, inlines)
@@ -31,7 +32,6 @@ def read_configuration(confFile: str, block_name: str):
                     inlines += 1
         return block
 
-
 def load_trex_config(confFile: str):
     """
     Load TRExFitter config file as a python dictionary
@@ -41,7 +41,6 @@ def load_trex_config(confFile: str):
     samples = read_configuration(confFile, "Sample")
     systematics = read_configuration(confFile, "Systematic")
     return {**job, **regions, **samples, **systematics}
-
 
 class LoadTRExConfig():
     """

--- a/servicex_for_trexfitter/servicex_for_trexfitter.py
+++ b/servicex_for_trexfitter/servicex_for_trexfitter.py
@@ -2,7 +2,7 @@ import time
 from .read_trex_config import LoadTRExConfig
 from .load_servicex_requests import LoadServiceXRequests
 from .communicate_servicex import ServiceXFrontend
-from .make_ntuples import make_ntuples
+from .make_ntuples import MakeNtuples
 
 
 class ServiceXTRExFitter:
@@ -44,7 +44,8 @@ class ServiceXTRExFitter:
         times.update({'t1': time.monotonic()})
 
         # Produce ROOT ntuples
-        output_path = make_ntuples(self._trex_config, requests, output_parquet_list)
+        mn = MakeNtuples(self._trex_config)
+        output_path = mn.make_ntuples(requests, output_parquet_list)
         times.update({'t2': time.monotonic()})
 
         if timer:

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,14 @@ import setuptools
 import codecs
 import os.path
 
+
 with open("README.md") as fh:
     long_description = fh.read()
-
 
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
     with codecs.open(os.path.join(here, rel_path), 'r') as fp:
         return fp.read()
-
 
 def get_version(rel_path):
     for line in read(rel_path).splitlines():
@@ -20,11 +19,11 @@ def get_version(rel_path):
     else:
         raise RuntimeError("Unable to find version string.")
 
-
 setuptools.setup(name="servicex_for_trexfitter",
                  version=get_version("servicex_for_trexfitter/__init__.py"),
                  packages=setuptools.find_packages(exclude=['tests']),
-                 description="Interface ServiceX into TRExFitter to provide an alternative method of reading input ntuples",
+                 description="Interface ServiceX into TRExFitter to provide an alternative method" 
+                     " of reading input ntuples",
                  long_description=long_description,
                  long_description_content_type='text/markdown',
                  author="KyungEon Choi (UT Austin)",


### PR DESCRIPTION
- Parquet to ROOT Ntuple conversion is now parallelized up to number of samples or half of available cpu threads.
- Fix GitHub action for the installation of root.
- Fix bug that ignores cached data.